### PR TITLE
Fix GSC parsing to detect multiple URLs

### DIFF
--- a/src/htmlTemplate.js
+++ b/src/htmlTemplate.js
@@ -123,12 +123,21 @@ function getClientScript() {
       const mappings = [];
 
       function parseGsc(text) {
-        return text
-          .split(/\\r?\\n/)
-          .map(line => line.trim())
-          .filter(line => line && !line.toLowerCase().startsWith('url'))
-          .map(line => line.split(/\\s+/)[0])
-          .filter(Boolean);
+        if (!text) {
+          return [];
+        }
+
+        const matches = text.match(/https?:\\/\\/[^\\s]+/gi) || [];
+        const urls = matches
+          .map(url => url.trim())
+          .filter(url => url && !url.toLowerCase().startsWith('url'));
+
+        // Remove any accidental trailing punctuation such as commas from copied text
+        return Array.from(
+          new Set(
+            urls.map(url => url.replace(/["'`,;]+$/, ''))
+          )
+        );
       }
 
       function parseSitemap(text) {


### PR DESCRIPTION
## Summary
- update the Google Search Console parser to match URLs using a regex instead of line splitting
- trim trailing punctuation and deduplicate URLs extracted from pasted exports

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d9be656018832599a707b2af5d390d