### PR TITLE
Improve GSC URL parsing

### DIFF
--- a/src/htmlTemplate.js
+++ b/src/htmlTemplate.js
@@ -127,17 +127,20 @@ function getClientScript() {
           return [];
         }
 
-        const matches = text.match(/https?:\\/\\/[^\\s]+/gi) || [];
-        const urls = matches
-          .map(url => url.trim())
-          .filter(url => url && !url.toLowerCase().startsWith('url'));
+        const matches = [];
+        const urlRegex = /(https?:\\/\\/[^\s"'`,;<>]+)/gi;
+        let match;
+        while ((match = urlRegex.exec(text)) !== null) {
+          const cleaned = match[1]
+            .trim()
+            .replace(/[)\]\}]+$/, '')
+            .replace(/["'`,;:.!?]+$/, '');
+          if (cleaned && !cleaned.toLowerCase().startsWith('url')) {
+            matches.push(cleaned);
+          }
+        }
 
-        // Remove any accidental trailing punctuation such as commas from copied text
-        return Array.from(
-          new Set(
-            urls.map(url => url.replace(/["'`,;]+$/, ''))
-          )
-        );
+        return Array.from(new Set(matches));
       }
 
       function parseSitemap(text) {


### PR DESCRIPTION
## Summary
- improve the GSC input parser to capture URLs separated by any delimiters
- strip trailing punctuation so every discovered URL can be mapped

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d9c36cca2c83259387308b0b4e0a2f