### PR TITLE
Escape backticks in client script regexes

### DIFF
--- a/src/htmlTemplate.js
+++ b/src/htmlTemplate.js
@@ -128,13 +128,13 @@ function getClientScript() {
         }
 
         const matches = [];
-        const urlRegex = /(https?:\\/\\/[^\s"'`,;<>]+)/gi;
+        const urlRegex = /(https?:\\/\\/[^\s"'\u0060,;<>]+)/gi;
         let match;
         while ((match = urlRegex.exec(text)) !== null) {
           const cleaned = match[1]
             .trim()
             .replace(/[)\]\}]+$/, '')
-            .replace(/["'`,;:.!?]+$/, '');
+            .replace(/["'\u0060,;:.!?]+$/, '');
           if (cleaned && !cleaned.toLowerCase().startsWith('url')) {
             matches.push(cleaned);
           }


### PR DESCRIPTION
## Summary
- escape the backtick in the GSC URL extraction regex so the template literal parses correctly
- escape the backtick in the cleanup regex to prevent template literal termination

## Testing
- npx wrangler deploy --dry-run

------
https://chatgpt.com/codex/tasks/task_e_68d9c5f144e48325b6d24a43bd8d89ef